### PR TITLE
feat: Remove merge-base option

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2.1
+version: 2.2
 
 setup: true
 orbs:

--- a/src/scripts/create-parameters.py
+++ b/src/scripts/create-parameters.py
@@ -104,7 +104,7 @@ def is_mapping_line(line: str) -> bool:
 def create_parameters(output_path, config_path, head, base, mapping):
   checkout(base)  # Checkout base revision to make sure it is available for comparison
   checkout(head)  # return to head commit
-  base = merge_base(base, head)
+  # base = merge_base(base, head)
 
   if head == base:
     try:


### PR DESCRIPTION
Due to the existing staging waterfall flow, we get re-deploys almost every time code is merged to staging.

This change tries to minimise the _damage_ caused by removing `merge-base` logic from the comparison flow.